### PR TITLE
Set rpath

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 if [ "$(uname)" == 'Darwin' ]
 then
-    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
 else
-    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath=$PREFIX/lib"
 fi
 
 
@@ -12,7 +12,7 @@ ln -s "${PREFIX}/lib/libopenblas${SHLIB_EXT}" "${PREFIX}/lib/liblapack${SHLIB_EX
 
 "${PYTHON}" setup.py install
 # Over using memory (too many threads?). Will have to look at later.
-#eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib "${PYTHON}" test_spams.py
+#"${PYTHON}" test_spams.py
 
 
 rm "${PREFIX}/lib/libblas${SHLIB_EXT}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
 
 build:
   skip: true  # [win or py3k]
-  number: 204
+  number: 205
   detect_binary_files_with_prefix: true
   features:
     - blas_{{ variant }}


### PR DESCRIPTION
Use linker flags to set the `rpath` as part of the build of libraries and/or executables. This should remove the need to use hacky solutions like mucking with the library search path.