### PR TITLE
Drop BLAS symlink hack

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,15 +6,8 @@ else
 fi
 
 
-ln -s "${PREFIX}/lib/libopenblas${SHLIB_EXT}" "${PREFIX}/lib/libblas${SHLIB_EXT}"
-ln -s "${PREFIX}/lib/libopenblas${SHLIB_EXT}" "${PREFIX}/lib/liblapack${SHLIB_EXT}"
-
-
 "${PYTHON}" setup.py install
 
-
-rm "${PREFIX}/lib/libblas${SHLIB_EXT}"
-rm "${PREFIX}/lib/liblapack${SHLIB_EXT}"
 
 rm -r "${PREFIX}/doc"
 rm -r "${PREFIX}/extdata"


### PR DESCRIPTION
This hack was added so that SPAMS would be able to pick up on OpenBLAS being installed and link to it. However now that OpenBLAS has these symlinks included in its package, it no longer makes sense to have this hack in SPAMS. Further the fact that symlinks were being created on top of existing files caused some build failures. Hence we remove the symlink steps.