### PR TITLE
Pin OpenBLAS to 0.2.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 202
+  number: 203
   detect_binary_files_with_prefix: true
   features:
     - blas_{{ variant }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - gcc
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
     - numpy 1.9.*
     - scipy
     # For tests.
@@ -53,7 +53,7 @@ requirements:
     - libgcc
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
     - numpy >=1.9
     - scipy
 


### PR DESCRIPTION
Bumps the OpenBLAS pin from 0.2.19 to 0.2.20.