### PR TITLE
Use newer URL for source

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.6.1" %}
-{% set date = "2017-12-08" %}
-{% set file_num = "37237" %}
+{% set date = "2018-08-06" %}
+{% set file_num = "37659" %}
 
 {% set variant = "openblas" %}
 


### PR DESCRIPTION
The original URL for the source has been pretty flaky lately. Namely it has been timing out frequently. This switches to the new URL one would find by merely downloading the source from the website. Should be a bit more reliable and thus fixing spurious CI failures due to HTTP errors.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
